### PR TITLE
fix typos

### DIFF
--- a/about.rst
+++ b/about.rst
@@ -11,7 +11,7 @@ About
 What is Netmaker?
 ==================
 
-Netmaker is a tool for creating and managing virtual overlay networks. If you have at least two machines with internet access which you need to connect with a secure tunnel, Netmaker is for you. If you have thousands of servers spread across multiple locations, data centers, or clouds, Netmaker is also for you. Netmaker connects machines securely, wherever they are.
+Netmaker is a tool for creating and managing virtual overlay networks. If you have at least two machines with internet access that you need to connect with a secure tunnel, Netmaker is for you. If you have thousands of servers spread across multiple locations, data centers, or clouds, Netmaker is also for you. Netmaker connects machines securely, wherever they are.
 
 .. image:: images/mesh-diagram.png
    :width: 50%
@@ -29,7 +29,7 @@ Beyond creating a flat network, Netmaker introduces Ingress and Egress, which ar
    :align: center
 
 
-Netmaker has many similarities to Tailscale, ZeroTier, and Nebula. What makes Netmaker different is the speed and flexibility. Netmaker is faster because it uses kernel WireGuard. It is more dynamic because the server and agents are fully configurable, which lets you handle all sorts of different use cases. And of course, you can also self-host Netmaker, which gives you complete control of your network traffic.
+Netmaker has many similarities to Tailscale, ZeroTier, and Nebula. What makes Netmaker different is the speed and flexibility. Netmaker is faster because it uses kernel WireGuard. It is more dynamic because the server and agents are fully configurable, which lets you handle all sorts of different use cases. And, of course, you can also self-host Netmaker, which gives you complete control of your network traffic.
 
 How Does Netmaker Work?
 =======================
@@ -39,7 +39,7 @@ Netmaker relies on WireGuard to create tunnels between machines. At its core, Ne
 - the admin server, called Netmaker
 - the agent, called Netclient
 
-As the network manager, you interact with the server to create and manage networks and devices. The server holds configurations for these networks and devices, and pushes updates to the agents (netclient) over a message queue.
+As the network manager, you interact with the server to create and manage networks and devices. The server holds configurations for these networks and devices and pushes updates to the agents (netclient) over a message queue.
 
 The netclient is installed on any machine you would like to add to a given network, whether that machine is a VM, Server, Kubernetes node, or IoT device. The netclient subscribes to the MQ broker, and the server tells it how to configure WireGuard. The client will let the server know when any local changes (like ip address, port) should be pushed out to the other clients. By doing this across many machines simultaneously, we create fully dynamic and configurable virtual networks.
 
@@ -48,9 +48,9 @@ The Netmaker server does not typically route traffic, which would be a hub-and-s
 Use Cases for Netmaker
 =============================
 
-There are many use cases for Netmaker. In fact, you could probably be using it right now. Because of Netmaker's extreme speed, there is almost no cost to putting a Netmaker overlay network on top of any existing Network. The question becomes, why not use Netmaker? You've already got the machines, why not encrypt the traffic and make your network dynamic?
+There are many use cases for Netmaker. In fact, you could probably be using it right now. Because of Netmaker's extreme speed, there is almost no cost to putting a Netmaker overlay network on top of any existing Network. The question becomes, why not use Netmaker? You've already got the machines; why not encrypt the traffic and make your network dynamic?
 
-This list is not all-encompassing, but provides a sample of how many users are using Netmaker in production today. Guided setup for many of these use cases can be found in the :doc:`Using Netmaker <./usage>` documentation. 
+This list is not all-encompassing but provides a sample of how many users use Netmaker in production today. Guided setup for many of these use cases can be found in the :doc:`Using Netmaker <./usage>` documentation. 
 
  0. Automate the creation of a large WireGuard-based network
  1. Create a flat, secure network between multiple environments (VPCs, clouds, data centers)

--- a/acls.rst
+++ b/acls.rst
@@ -21,9 +21,9 @@ The ACL feature can be accessed by either clicking on "ACLs" in the sidebar, or 
 ACL Screen
 --------------
 
-If you are on the ACLs tab (pictured above), you will have a full list of all ACLs for the whole network. You can simply click on any one of these to enable or disable a pair of connections. You will note that when you "disable" the connection from any one node, it will automatically "disable" the matching connection on the other node. An update is sent to the nodes over MQ, telling them to remove the connection locally.
+If you are on the ACLs tab (pictured above), you will have a complete list of all ACLs for the whole network. You can simply click on any one of these to enable or disable a pair of connections. You will note that when you "disable" the connection from any one node, it will automatically "disable" the matching connection on the other node. An update is sent to the nodes over MQ, telling them to remove the connection locally.
 
-In the upper right-hand corner of the screen you will also notice an "Allow All" button and a "Block All" button. "Allow All" will enable all connections, and "Block All" will block all connections. If you block all connections, no nodes will be able to talk to each other.
+In the upper right-hand corner of the screen, you will also notice an "Allow All" button and a "Block All" button. "Allow All" will enable all connections, and "Block All" will block all connections. If you block all connections, no nodes will be able to talk to each other.
 
 For more information, see the :doc:`UI reference. <./ui-reference>`
 
@@ -41,6 +41,6 @@ Alternatively, you can reach the individual node ACLs by clicking on a Node in e
 Important Note about UDP Hole Punching
 -------------------------------------------
 
-As of 0.12.0, we allow you to disable any p2p connection, including a node's connection to the server (e.g. netmaker-1). **If you disable this connection and you use UDP Hole Punching, your network will break.** Why? The netmaker server collects the endpoints/ports necessary to reach every node, and then sends this information to the network. If this connection is disabled, the server will not know how to reach the given node.
+As of 0.12.0, we allow you to disable any p2p connection, including a node's connection to the server (e.g. netmaker-1). **If you disable this connection and you use UDP Hole Punching, your network will break.** Why? The netmaker server collects the endpoints/ports necessary to reach every node and then sends this information to the network. If this connection is disabled, the server will not know how to reach the given node.
 
-As an alternative, you can turn off UDP Hole Punching on the individual node, if you do not wish for it to communicate with the server.
+As an alternative, you can turn off UDP Hole Punching on the individual node if you do not wish for it to communicate with the server.

--- a/api.rst
+++ b/api.rst
@@ -10,9 +10,9 @@ Most actions that can be performed via API can be performed via UI. We recommend
 
 Authentication
 ==============
-API calls must be authenticated via a header of  the format  `-H "Authorization: Bearer <YOUR_SECRET_KEY>"` There are two methods to obtain YOUR_SECRET_KEY:
+API calls must be authenticated via a header of the format  `-H "Authorization: Bearer <YOUR_SECRET_KEY>"` There are two methods to obtain YOUR_SECRET_KEY:
 1. Using the masterkey. By default, this value is "secret key," but you should change this on your instance and keep it secure. This value can be set via env var at startup or in a config file (config/environments/< env >.yaml). See the [general usage](./USAGE.md) documentation for more details.
-2. Using a JWT received for a node. This  can be retrieved by calling the `/api/nodes/<network>/authenticate` endpoint, as documented below.
+2. Using a JWT received for a node. This can be retrieved by calling the `/api/nodes/<network>/authenticate` endpoint, as documented below.
 
 
 Format of Calls for Curl
@@ -141,7 +141,7 @@ Nodes API Call Examples
 Users API
 -----------------------
   
-**Note:** Only able to create Admin user at this time. The "user" is only used by the `user interface <https://github.com/gravitl/netmaker-ui>`_ to authenticate the  single  admin user.
+**Note:** Only able to create Admin user at this time. The "user" is only used by the `user interface <https://github.com/gravitl/netmaker-ui>`_ to authenticate the single admin user.
 
 **Get User:** `/api/users/{username}`, `GET`  
   

--- a/architecture.rst
+++ b/architecture.rst
@@ -14,14 +14,14 @@ Architecture
 Core Concepts
 ==============
 
-Familiarity with several core concepts will help when you encounter them later on in the documentation.
+Familiarity with several core concepts will help when you encounter them later in the documentation.
 
 WireGuard
 ----------
 
-WireGuard is a relatively new but very important technology which was recently added to the Linux kernel. WireGuard creates very fast but simple encrypted tunnels between devices. From the `WireGuard <https://www.wireguard.com/>`_ website, "it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry."
+WireGuard is a relatively new but very important technology that was recently added to the Linux kernel. WireGuard creates very fast but simple encrypted tunnels between devices. From the `WireGuard <https://www.wireguard.com/>`_ website, "it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry."
 
-Previous solutions like OpenVPN and IPSec are considerably more heavy and complex, while being less performant. All existing VPN tunneling solutions will cause a significant increase in your network latency. WireGuard is the first to achieve near over-the-line network speeds, meaning you see no significant performance impact.  With the release of WireGuard, there is little reason to use any other existing tunnel encryption technology.
+Previous solutions like OpenVPN and IPSec are considerably more heavy and complex while being less performant. All existing VPN tunneling solutions will cause a significant increase in your network latency. WireGuard is the first to achieve near over-the-line network speeds, meaning you see no significant performance impact.  With the release of WireGuard, there is little reason to use any other existing tunnel encryption technology.
 
 Mesh Network
 -------------
@@ -38,20 +38,20 @@ A full `mesh network <https://www.bbc.co.uk/bitesize/guides/zr3yb82/revision/2>`
 
 This is in contrast to a hub-and-spoke network, where each machine must first pass its traffic through a relay server before it can reach other machines.
 
-In certain situations you may either want or need a *partial mesh* network, where only some devices can reach each other directly, and other devices must route their traffic through a relay/gateway. Netmaker can use this model in some use cases where it makes sense. In the diagram at the top of this page, the setup is a partial mesh, because the servers (nodes A-D) are meshed, but then external clients come in via a gateway, and are not meshed.
+In certain situations, you may either want or need a *partial mesh* network, where only some devices can reach each other directly, and other devices must route their traffic through a relay/gateway. Netmaker can use this model in some use cases where it makes sense. In the diagram at the top of this page, the setup is a partial mesh because the servers (nodes A-D) are meshed, but then external clients come in via a gateway and are not meshed.
 
-Mesh networks are generally faster than other topologies, but are also more complicated to set up. WireGuard on its own gives you the means to create encrypted tunnels between devices, but it does not provide a method for setting up a full network. This is where Netmaker comes in.
+Mesh networks are generally faster than other topologies but are also more complicated to set up. WireGuard on its own gives you the means to create encrypted tunnels between devices, but it does not provide a method for setting up a full network. This is where Netmaker comes in.
 
 Netmaker
 ---------
 
-Netmaker is a platform built off of WireGuard which enables users to create mesh networks between their devices. Netmaker can create both full and partial mesh networks depending on the use case.
+Netmaker is a platform built off of WireGuard enabling users to create mesh networks between their devices. Netmaker can create both full and partial mesh networks depending on the use case.
 
-When we refer to Netmaker in aggregate, we are typically referring to Netmaker and the netclient, as well as other supporting services such as CoreDNS, sqlite,  Mosquitto (MQ Broker) and UI webserver. There is also almost always a proxy server / LB, which is typically Caddy.
+When we refer to Netmaker in aggregate, we are typically referring to Netmaker and the netclient, as well as other supporting services such as CoreDNS, SQLite,  Mosquitto (MQ Broker), and UI webserver. There is also almost always a proxy server / LB, which is typically Caddy.
 
 From an end user perspective, they typically interact with the Netmaker UI, or even just run the install script for the netclient on their devices. The other components run in the background invisibly. 
 
-Netmaker does a lot of work to set configurations for you, so that you don't have to. This includes things like WireGuard ports, endpoints, public IPs, keys, and peers. Netmaker works to abstract away as much of the network management as possible, so that you can just click to create a network, and click to add a machine to a network. That said, every machine (node) is different, and may require special configuration. That is why, while Netmaker sets practical default settings, everything within Netmaker is fully configurable.
+Netmaker does a lot of work to set configurations for you so that you don't have to. This includes things like WireGuard ports, endpoints, public IPs, keys, and peers. Netmaker works to abstract away as much of the network management as possible, so that you can just click to create a network, and click to add a machine to a network. That said, every machine (node) is different, and may require special configuration. That is why, while Netmaker sets practical default settings, everything within Netmaker is fully configurable.
 
 Node
 ------
@@ -66,24 +66,24 @@ Netmaker consists of several core components, which are explained in high-level 
 Netmaker Server
 ------------------
 
-The Netmaker server is, at its core, a golang binary. Source code can be found `on GitHub <https://github.com/gravitl/netmaker>`_. The binary, by itself can be compiled for most systems. If you need to run the Netmaker server on a particular system, it likely can be made to work. In typical deployments, it is run as a Docker container. It can also be run as a systemd service as outlined in the non-docker install guide.
+The Netmaker server is, at its core, a golang binary. Source code can be found `on GitHub <https://github.com/gravitl/netmaker>`_. The binary, by itself, can be compiled for most systems. If you need to run the Netmaker server on a particular system, it likely can be made to work. In typical deployments, it is run as a Docker container. It can also be run as a systemd service as outlined in the non-docker install guide.
 
-The Netmaker server acts as an API to the front end, and publishes messages to clients via an MQ broker. The Netmaker server also runs an embedded "netclient" for each network that is created. This is a special netclient that enabled "UDP Hole Punching" on the system. When nodes reach the server, Netmaker uses this netclient to determine a routable address for each machine, and sends this out to the network.
+The Netmaker server acts as an API to the front end and publishes messages to clients via an MQ broker. The Netmaker server also runs an embedded "netclient" for each network that is created. This is a special netclient that enabled "UDP Hole Punching" on the system. When nodes reach the server, Netmaker uses this netclient to determine a routable address for each machine, and sends this out to the network.
 
 Most server settings are configurable via a config file, or by environment variables (which take precedence). If the server finds neither of these, it sets sensible defaults, including things like the server's reachable IP, ports, and which "modes" to run in.
 
-The Netmaker server interacts with either sqlite (default), postgres, or rqlite, a distributed version of sqlite, as its database. This DB holds information about nodes, networks, users, and other important data. This data is configuration data. 
+The Netmaker server interacts with either SQLite (default), postgres, or rqlite, a distributed version of SQLite, as its database. This DB holds information about nodes, networks, users, and other important data. This data is configuration data. 
 
-When the netmaker server needs to send an update to nodes, is publishes a message to the broker, MQ.
+When the netmaker server needs to send an update to nodes, it publishes a message to the broker, MQ.
 
-The components of the server are usually proxied via Caddy, or an alternative like Nginx or Traefik. The proxy handles SSL certificates to secure traffic, and routes to the UI and API.
+The components of the server are usually proxied via Caddy or an alternative like Nginx or Traefik. The proxy handles SSL certificates to secure traffic, and routes to the UI and API.
 
 Message Broker (Mosquitto)
 ---------------------------
 
-The Moquitto broker is the default MQTT broker that ships with Netmaker, though technically, any MQTT broker should work so long as the correct configuration is applied. The broker enables the establishment of a pub-sub messaging system, whereby clients subscribe to recieve updates. When the server recieves a change, it will publish that change to the broker that pushes out the change to the appropriate nodes. 
+The Mosquitto broker is the default MQTT broker that ships with Netmaker, though technically, any MQTT broker should work so long as the correct configuration is applied. The broker enables the establishment of a pub-sub messaging system, whereby clients subscribe to receive updates. When the server receives a change, it will publish that change to the broker that pushes out the change to the appropriate nodes. 
 
-The broker must be reachable over a public address. Unlike the API and UI, Netmaker handles certificates for MQ directly, and MQ is NOT proxied via Caddy. Netmaker shares a folder for certificates with MQ, and generates root certs as well as client certs, which are distributed to each machine. This keeps MQ traffic secure on a per-peer basis. As of 0.13.1, The certificate management system is still relatively new, and this is often a point of initial setup failure, due to either incorrect DNS, firewall, or MQ setup.
+The broker must be reachable over a public address. Unlike the API and UI, Netmaker handles certificates for MQ directly, and MQ is NOT proxied via Caddy. Netmaker shares a folder for certificates with MQ, and generates root certs as well as client certs, which are distributed to each machine. This keeps MQ traffic secure on a per-peer basis. As of 0.13.1, The certificate management system is still relatively new, and this is often a point of initial setup failure due to either incorrect DNS, firewall, or MQ setup.
 
 Netclient
 ----------------
@@ -94,20 +94,20 @@ The netclient is installed via a simple bash script, which pulls the latest bina
 
 The 'join' command attempts to add the machine to the Netmaker network using sensible defaults, which can be overridden with a config file or environment variables. Assuming the netclient has a valid key (or the network allows manual node signup), it will be registered into the Netmaker network, and will be returned necessary configuration details for how to set up its local network. 
 
-The netclient automatically registers with the MQTT server running with Netmaker, which will send it periodic updates when the network changes. The netclient recieves the certificates necessary to reach the broker over a secure connection.
+The netclient automatically registers with the MQTT server running with Netmaker, which will send it periodic updates when the network changes. The netclient receives the certificates necessary to reach the broker over a secure connection.
 
-The netclient then sets up the system daemon (if running in daemon mode), and configures WireGuard. At this point it should be part of the network.
+The netclient then sets up the system daemon (if running in daemon mode), and configures WireGuard. At this point, it should be part of the network.
 
 The netclient will detect local changes and send them to the server when necessary. A change to IP address or port will lead to a network update to keep everything in sync. If the node is not running with the in daemon on, it is up to the operator to keep the netclient up-to-date by running regular "pulls" (netclient pull).
 
-The MQ pub-sub system allows Netmaker to create dynamic mesh networks. As nodes are added to, removed from, and modified on the network, other nodes are notified, and make appropriate changes.
+The MQ pub-sub system allows Netmaker to create dynamic mesh networks. As nodes are added to, removed from, and modified on the network, other nodes are notified and make appropriate changes.
 
-Database (sqlite, rqlite, postgres)
+Database (SQLite, rqlite, postgres)
 -------------------------------------
 
-Netmaker uses embedded sqlite as the default database. It can also use PostgreSQL, or rqlite, a distributed (RAFT consensus) database. Netmaker interacts with the database to store and retrieve information about nodes, networks, and users. 
+Netmaker uses embedded SQLite as the default database. It can also use PostgreSQL, or rqlite, a distributed (RAFT consensus) database. Netmaker interacts with the database to store and retrieve information about nodes, networks, and users. 
 
-Additional database support (besides sqlite and rqlite) is very easy to implement for special use cases. Netmaker uses simple key value lookups to run the networks, and the database was designed to be extensible, so support for key-value stores and other SQL-based databases can be achieved by changing a single file.
+Additional database support (besides SQLite and rqlite) is very easy to implement for special use cases. Netmaker uses simple key-value lookups to run the networks, and the database was designed to be extensible, so support for key-value stores and other SQL-based databases can be achieved by changing a single file.
 
 Netmaker UI
 ---------------
@@ -120,11 +120,11 @@ Netmaker can be used in its entirety without the UI, but the UI makes things a l
 CoreDNS
 --------
 
-As of 0.12.0, CoreDNS is not an active part of the Netmaker system. Nodes DO NOT recieve their DNS updates using a nameserver. Instead, DNS entries are added to the local "hosts" file directly. The CoreDNS component can be safely removed from the setup and DNS will continue to function.
+As of 0.12.0, CoreDNS is not an active part of the Netmaker system. Nodes DO NOT receive their DNS updates using a nameserver. Instead, DNS entries are added to the local "hosts" file directly. The CoreDNS component can be safely removed from the setup and DNS will continue to function.
 
-Previously, CoreDNS was used as a nameserver and the netclient would set the nameserver per-peer. However, this only worked on a subset of linux systems, because it required resolvectl. The new method (using the hosts file) works across OS's.
+Previously, CoreDNS was used as a nameserver and the netclient would set the nameserver per peer. However, this only worked on a subset of Linux systems, because it required resolvectl. The new method (using the hosts file) works across OSs.
 
-However, we still maintain CoreDNS in the default deployment for 2 reasons:  
+However, we still maintain CoreDNS in the default deployment for two reasons:  
   1. You may wish to add a nameserver to "Ext Clients". CoreDNS can still be used for this.  
   2. You may wish to integrate the Netmaker nameserver with your existing DNS setup.  
 
@@ -144,20 +144,20 @@ External Client
 
 The external client is simply a manually configured WireGuard connection to your network, which Netmaker helps to manage.
 
-Most machines can run WireGuard. It is fairly simple to set up a WireGuard connection to a single endpoint. It is setting up mesh networks and other topologies like site-to-site which becomes complicated. 
+Most machines can run WireGuard. Setting up a WireGuard connection to a single endpoint is fairly simple. It is setting up mesh networks and other topologies like site-to-site which becomes complicated. 
 
 Mac, Windows, and Linux are handled natively by the Netclient, though you can still add them as ext clients if you wish. Primarily, iPhone and Android are the main systems unsupported by the Netclient which MUST be handled via external client.
 
 External clients hook into a Netmaker network via an "Ingress Gateway," which is configured for a given node and allows traffic to flow into the network. External clients are also reachable via the gateway. While this is a "concentrator" and not peer-to-peer, this is often desirable.
 
-Many users use external clients as a convenient way to manage remote access for their users. Why? It works with vanilla WireGuard for one. You simply download the config and load it into WireGuard on the client device. No additional software required. It can also be quite helpful to have a "choke point" for traffic (the gateway) rather than direct p2p connections to every machine.
+Many users use external clients as a convenient way to manage remote access for their users. Why? It works with vanilla WireGuard for one. You simply download the config and load it into WireGuard on the client device. No additional software is required. It can also be quite helpful to have a "choke point" for traffic (the gateway) rather than direct p2p connections to every machine.
 
 Technical Process
 ====================
 
 Below is a high level, step-by-step overview of the flow of communications within Netmaker (assuming Netmaker has already been installed):
 
-1. Admin creates a new network with a subnet, for instance 10.10.10.0/24
+1. Admin creates a new network with a subnet, for instance, 10.10.10.0/24
 2. Admin creates an access key for signing up new nodes
 3. Both of the above requests are routed to the server via an API call from the front end
 4. Admin runs the netclient install script on any given node (machine).
@@ -170,14 +170,14 @@ Below is a high level, step-by-step overview of the flow of communications withi
 11. Netclient subscribes to the MQ broker.
 12. Netclient configures itself as a daemon (if joining for the first time).
 13. Netclient regularly retrieves local information, checking for changes in things like IP and keys. If there is a change, it pushes them to the server.
-14. If a change occurs in any other peer, or peers are added/removed, an update will be sent to the Netclient via MQ, and it will re-configure WireGuard.
+14. If a change occurs in any other peer or peers are added/removed, an update will be sent to the Netclient via MQ, and it will re-configure WireGuard.
 
 Compatible Systems for Netclient
 ==================================
 
-To manage a node manually, the Netclient can be compiled and run for most linux distibutions, with a prerequisite of WireGuard with kernel headers. If the netclient from the release pages does not run natively on your system, you may need to compile the netclient binary directly on the machine from the source code. This may be true for some installations of SUSE, Fedora, and some Debian-based systems. However, if the dependencies are installed on the machine, the netclient should run correctly after being compiled.
+To manage a node manually, the netclient can be compiled and run for most Linux distibutions, with a prerequisite of WireGuard with kernel headers. If the netclient from the release pages does not run natively on your system, you may need to compile the netclient binary directly on the machine from the source code. This may be true for some installations of SUSE, Fedora, and some Debian-based systems. However, if the dependencies are installed on the machine, the netclient should run correctly after being compiled.
 
-Simply clone the repo, cd to netmaker/netclient and run "go build" (Golang must be installed).
+Simply clone the repo, cd to netmaker/netclient, and run "go build" (Golang must be installed).
 
 The following systems should be operable natively with Netclient in daemon mode:
         - Windows
@@ -195,7 +195,7 @@ The following systems should be operable natively with Netclient in daemon mode:
         - CentOS
         - Fedora CoreOS
 
-Systemd is a system service manager for a wide array of Linux operating systems, but not all Linux distributions have adopted systemd. If you need to run on a Linux distro without systemd, we recommend the following: Join "unmanaged" with **netclient join -daemon=off** on Linux systems that do not run systemd, and use some other method to run the daemon like a cron job or custom script.
+Systemd is a system service manager for a wide array of Linux operating systems, but not all Linux distributions have adopted systemd. If you need to run on a Linux distro without systemd, we recommend the following: Join "unmanaged" with **netclient join -daemon=off** on Linux systems that do not run systemd and use some other method to run the daemon like a cron job or custom script.
 
 
 Limitations

--- a/external-clients.rst
+++ b/external-clients.rst
@@ -15,13 +15,13 @@ Netmaker allows for "external clients" to reach into a network and access servic
         - Laptops
         - Desktops
 
-An external client is not "managed," meaning it does not automatically pull the latest network configuration, or push changes to its configuration. Instead, it uses a generated WireGuard config file to access the designated **Ingress Gateway**, which **is** a managed server (running netclient). This server then forwards traffic to the appropriate endpoint, acting as a middle-man/relay.
+An external client is not "managed," meaning it does not automatically pull the latest network configuration or push changes to its configuration. Instead, it uses a generated WireGuard config file to access the designated **Ingress Gateway**, which **is** a managed server (running netclient). This server then forwards traffic to the appropriate endpoint, acting as a middle-man/relay.
 
 By using this method, you can hook any machine into a netmaker network that can run WireGuard.
 
 It is recommended to run the netclient where compatible, but for all other cases, a machine can be configured as an external client.
 
-Important to note, an external client is not **reachable** by the network, meaning the client can establish connections to other machines, but those machines cannot independently establish a connection back. The External Client method should only be used in use cases where one wishes to access resource running on the virtual network, and **not** for use cases where one wishes to make a resource accessible on the network. For that, use netclient.
+Important to note, that an external client is not **reachable** by the network, meaning the client can establish connections to other machines, but those machines cannot independently establish a connection back. The External Client method should only be used in use cases where one wishes to access resources running on the virtual network and **not** for use cases where one wishes to make a resource accessible on the network. For that, use netclient.
 
 Configuring an Ingress Gateway
 ==================================
@@ -50,7 +50,7 @@ After creating a client, you can edit the name to something more logical.
    :alt: Gateway
    :align: center
 
-Then, you can either download the configuration file directly, or scan the QR code from your phone (assuming you have the WireGuard app installed). It will accept the configuration just as it would accept a typical WireGuard configuration file.
+Then, you can either download the configuration file directly or scan the QR code from your phone (assuming you have the WireGuard app installed). It will accept the configuration just as it would accept a typical WireGuard configuration file.
 
 .. image:: images/exclient4.png
    :width: 80%
@@ -67,7 +67,7 @@ Configuring DNS for Ext Clients (OPTIONAL)
 ============================================
 
 If you wish to have a DNS field on your ext clients conf, simply edit the network field as shown below to 1.1.1.1 or 8.8.8.8 for example.
-If you do not want DNS on your ext client conf files, simply leave it blank.
+If you do not want DNS on your ext client conf files, leave it blank.
 
 .. image:: images/extclient5.png
    :width: 80%

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -35,7 +35,7 @@ Network Settings Description
 
 The Network creation form has a few fields which may seem unfamiliar. Here is a brief description:
 
-**UDP Hole Punching:** UDP Hole Punching enables the server to perform STUN. This means, when nodes check in, the server will record return addresses and ports. It will then communicate this information to the other nodes when they check in, allowing them to reach their peers more easily. This has two benefits. For one, it%. It also means, you dont usually have to worry about opening up the local firewall for ports (for instance, 51821). **This setting is usually good to turn on, with some noteable exceptions.** This setting cannot be enabled if "client mode" is turned off. This setting can also break peer-to-peer functionality if, for whatever reason, nodes are unable to reach the server.
+**UDP Hole Punching:** UDP Hole Punching enables the server to perform STUN. This means, when nodes check-in, the server will record return addresses and ports. It will then communicate this information to the other nodes when they check in, allowing them to reach their peers more easily. This has two benefits. For one, it%. It also means, you dont usually have to worry about opening up the local firewall for ports (for instance, 51821). **This setting is usually good to turn on, with some noteable exceptions.** This setting cannot be enabled if "client mode" is turned off. This setting can also break peer-to-peer functionality if, for whatever reason, nodes are unable to reach the server.
 
 **Is Local Network:**  This is almost always best to leave this turned off and is left for very special circumstances. If you are running a data center or a private WAN, you may want to enable this setting. It defines the range that nodes will set for Endpoints. Usually, Endpoints are just the public IP. But in some cases, you don't want any nodes to be reachable via a public IP, and instead want to use a private range.
 
@@ -76,13 +76,13 @@ Networks can also be enabled to allow nodes to sign up without keys at all. In t
 Deploy Nodes
 =================
 
-0. Prereqisite: Every machine on which you install should have wireguard and systemd already installed.
+0. Prereqisite: Every machine on which you install should have WireGuard and systemd already installed.
 
 1. SSH to each machine 
 2. ``sudo su -``
 3. **Prerequisite Check:** Every Linux machine on which you run the netclient must have WireGuard and systemd installed
-4. For linux machines with SystemD and WireGuard installed, Run the install command, Ex: ``curl -sfL https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/netclient-install.sh | KEY=vm3ow4thatogiwnsla3thsl3894ths sh -``
-5. For Mac, Windows, and arch-specific linux distributions (e.g. ARM), `download the appropriate netclient for your system <https://github.com/gravitl/netmaker/releases/tag/latest/>`_ . Then, run "netclient join -t <your token>".
+4. For Linux machines with systemd and WireGuard installed, run the install command, Ex: ``curl -sfL https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/netclient-install.sh | KEY=vm3ow4thatogiwnsla3thsl3894ths sh -``
+5. For Mac, Windows, and arch-specific Linux distributions (e.g. ARM), `download the appropriate netclient for your system <https://github.com/gravitl/netmaker/releases/tag/latest/>`_ . Then, run "netclient join -t <your token>".
 
 You should get output similar to the below. The netclient retrieves local settings, submits them to the server for processing, and retrieves updated settings. Then it sets the local network configuration. For more information about this process, see the :doc:`client installation <./client-installation>` documentation. If this process failed and you do not see your node in the console (see below), then reference the :doc:`troubleshooting <./troubleshoot>` documentation.
 
@@ -118,7 +118,7 @@ Your machines should now be visible in the control pane.
    :alt: Node Success
    :align: center
 
-You can view/modify/delete any node by selecting it in the NODES tab. For instance, you can change the name to something more sensible like "workstation" or "api server". You can also modify network settings here, such as keys or the WireGuard port. These settings will be picked up by the node on its next check in. For more information, see Advanced Configuration in the :doc:`Using Netmaker <./usage>` docs.
+You can view/modify/delete any node by selecting it in the NODES tab. For instance, you can change the name to something more sensible like "workstation" or "api server". You can also modify network settings here, such as keys or the WireGuard port. These settings will be picked up by the node on its next check-in. For more information, see Advanced Configuration in the :doc:`Using Netmaker <./usage>` docs.
 
 .. image:: images/node-details.png
    :width: 80%
@@ -127,7 +127,7 @@ You can view/modify/delete any node by selecting it in the NODES tab. For instan
 
 
 
-Nodes can be added/removed/modified on the network at any time. Nodes can also be added to multiple Netmaker networks. Any changes will get picked up by any nodes on a given network, and will take aboue ~30 seconds to take effect.
+Nodes can be added/removed/modified on the network at any time. Nodes can also be added to multiple Netmaker networks. Any changes will get picked up by any nodes on a given network and will take about ~30 seconds to take effect.
 
 Uninstalling the netclient
 =============================

--- a/relay-server.rst
+++ b/relay-server.rst
@@ -10,7 +10,7 @@ Introduction
    :alt: Relay
    :align: center
 
-Sometimes nodes are in hard-to-reach places. Typically this will be due to a CGNAT, Double NAT, or restrictive firewall. In such scenarios, a direct peer-to-peer connection with all other nodes might be impossible.
+Sometimes nodes are in hard-to-reach places. Typically this will be due to a CGNAT, Double NAT, or a restrictive firewall. In such scenarios, a direct peer-to-peer connection with all other nodes might be impossible.
 
 For this reason, Netmaker has a Relay Server functionality. At any time you may designate a publicly reachable node (such as the Netmaker Server) as a Relay, and tell it which machines it should relay. Then, all traffic routing to and from that machine will go through the relay. This allows you to circumvent the above issues and ensure connectivity when direct measures do not work.
 

--- a/server-installation.rst
+++ b/server-installation.rst
@@ -2,7 +2,7 @@
 Advanced Server Installation
 =================================
 
-This section outlines installing the Netmaker server, including Netmaker, Netmaker UI, rqlite, and CoreDNS
+This section outlines installing the Netmaker server, including Netmaker, Netmaker UI, rqlite, and CoreDNS.
 
 System Compatibility
 ====================
@@ -13,7 +13,7 @@ Typically, Netmaker is run inside of containers, using Docker or Kubernetes.
 
 Netmaker can be run without containers, but this is not recommended. You must run the Netmaker binary, CoreDNS binary, database, and a web server directly on the host.
 
-Each of these components have their own individual requirements and the management complexity increases exponentially by running outside of containers.
+Each of these components has its own individual requirements and the management complexity increases exponentially by running outside of containers.
 
 For first-time installs, we recommend the quick install guide. The following documents are meant for more advanced installation environments and are not recommended for most users. However, these documents can be helpful in customizing or troubleshooting your own installation. 
 
@@ -21,7 +21,7 @@ For first-time installs, we recommend the quick install guide. The following doc
 Server Configuration Reference
 ==========================================
 
-Netmaker sets its configuration in the following order of precendence:  
+Netmaker sets its configuration in the following order of precedence:  
 
 1. **Defaults:** Default values set on the server if no value is provided in configuration.  
 2. **Config File:** Values set in the `config/environments/*.yaml`` file 
@@ -38,14 +38,14 @@ SERVER_NAME
     **Description:**  MUST SET THIS VALUE. This is the public, resolvable DNS name of the MQ Broker. For instance: broker.netmaker.example.com.
 
 SERVER_HOST
-    **Default:** (Server detects public IP address of machine)
+    **Default:** (Server detects the public IP address of machine)
 
     **Description:** The public IP of the server where the machine is running. 
 
 SERVER_API_CONN_STRING
     **Default:** ""
 
-    **Description:**  MUST SET THIS VALUE. This is the public, resolvable address of the API, including port. For instance: api.netmaker.example.com:443.
+    **Description:**  MUST SET THIS VALUE. This is the public, resolvable address of the API, including the port. For instance: api.netmaker.example.com:443.
 
 COREDNS_ADDR
     **Default:** ""
@@ -151,7 +151,7 @@ TELEMETRY
 MQ_HOST 
     **Default:** (public IP of server)
 
-    **Description:** The address of the mq server. If running from docker compose it will be "mq". If using "host networking", it will find and detect the IP of the mq container. Otherwise, need to input address. If not set, it will use the public IP of the server. the port 1883 will be appended automatically. This is the expected reachable port for MQ and cannot be changed at this time.
+    **Description:** The address of the mq server. If running from docker compose it will be "mq". If using "host networking", it will find and detect the IP of the mq container. Otherwise, need to input address. If not set, it will use the public IP of the server. The port 1883 will be appended automatically. This is the expected reachable port for MQ and cannot be changed at this time.
 
 HOST_NETWORK: 
     **Default:** "off"
@@ -166,7 +166,7 @@ MANAGE_IPTABLES:
 PORT_FORWARD_SERVICES: 
     **Default:** ""
 
-    **Description:** Comma-separated list of services for which to configure port forwarding on the machine. Options include "mq,dns,ssh". MQ IS DEPRECIATED, DO NOT SET THIS.'ssh' forwards port 22 over wireguard, enabling ssh to server over wireguard. However, if you set the Netmaker server as a ingress gateway, this will break SSH on external clients, so be careful. DNS enables private dns over wireguard. If you would like to use private dns with ext clients, turn this on.
+    **Description:** Comma-separated list of services for which to configure port forwarding on the machine. Options include "mq,dns,ssh". MQ IS DEPRECIATED, DO NOT SET THIS.'ssh' forwards port 22 over WireGuard, enabling ssh to server over WireGuard. However, if you set the Netmaker server as an ingress gateway, this will break SSH on external clients, so be careful. DNS enables private DNS over WireGuard. If you would like to use private DNS with ext clients, turn this on.
 
 POD_IP: 
     **Default:** "127.0.0.1"
@@ -177,7 +177,7 @@ POD_IP:
 VERBOSITY:
     **Default:** 0
 
-    **Description:** Specify level of logging you would like on the server. Goes up to 3 for debugging. If you run into issues, up the verbosity.
+    **Description:** Specify the level of logging you would like on the server. Goes up to 3 for debugging. If you run into issues, up the verbosity.
 
 
 Config File Reference
@@ -190,7 +190,7 @@ A config file may be placed under config/environments/<env-name>.yml. To read th
 Compose File - Annotated
 --------------------------------------
 
-All environment variables and options are enabled in this file. It is the equivalent to running the "full install" from the above section. However, all environment variables are included, and are set to the default values provided by Netmaker (if the environment variable was left unset, it would not change the installation). Comments are added to each option to show how you might use it to modify your installation.
+All environment variables and options are enabled in this file. It is the equivalent to running the "full install" from the above section. However, all environment variables are included and are set to the default values provided by Netmaker (if the environment variable was left unset, it would not change the installation). Comments are added to each option to show how you might use it to modify your installation.
 
 .. literalinclude:: ./examplecode/docker-compose.reference.yml
   :language: YAML
@@ -203,12 +203,12 @@ The default options for docker-compose can be found here: https://github.com/gra
 The following is a brief description of each:
 
 - `docker-compose.contained.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.contained.yml>`_ - This is the default docker-compose, used in the quick start and deployment script in the README on GitHub. It deploys Netmaker with all options included (Caddy and CoreDNS) and has "self-contained" netclients, meaning they do not affect host networking.
-- `docker-compose.coredns.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.coredns.yml>`_ - This is a simple compose used to spin up a standalone CoreDNS server. Can be useful if, for instance, you are unning Netmaker on baremetal but need CoreDNS.
+- `docker-compose.coredns.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.coredns.yml>`_ - This is a simple compose used to spin up a standalone CoreDNS server. Can be useful if, for instance, you are running Netmaker on baremetal but need CoreDNS.
 - `docker-compose.hostnetwork.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.hostnetwork.yml>`_ - This is similar to the docker-compose.contained.yml but with a key difference: it has advanced permissions and mounts host volumes to control networking on the host level.
 - `docker-compose.nocaddy.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.nocaddy.yml>`_ -= This is the same as docker-compose.contained.yml but without Caddy, in case you need to use a different proxy like Nginx, Traefik, or HAProxy.
 - `docker-compose.nodns.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.nodns.yml>`_ - This is the same as docker-compose.contained.yml but without CoreDNS, in which case you will not have the Private DNS feature.
 - `docker-compose.reference.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.reference.yml>`_ - This is the same as docker-compose.contained.yml but with all variable options on display and annotated (it's what we show right above this section). Use this to determine which variables you should add or change in your configuration.
-- `docker-compose.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.yml>`_ - This is a renamed docker-compose.contained.yml. It is meant only to act as a placeholder for what we consider the "primary" docker-compose that users should work with.
+- `docker-compose.yml <https://github.com/gravitl/netmaker/blob/master/compose/docker-compose.yml>`_ - This is a renamed docker-compose.contained.yml. It is meant only to act as a placeholder for what we consider the "primary" docker-compose users should work with.
 
 
 Traefik Proxy
@@ -220,21 +220,21 @@ To install with Traefik, rather than Nginx or the default Caddy, check out this 
 No DNS - CoreDNS Disabled
 ----------------------------------------------
 
-CoreDNS is no longer required for most installs. You can simply remove the CoreDNS section from your docker-compose. DNS will still function, because it is added directly to nodes' hosts files (ex: /etc/hosts). If you would like to disable DNS propagation entirely, in your docker-compose env for netmaker, set DNS_MODE="off"
+CoreDNS is no longer required for most installs. You can simply remove the CoreDNS section from your docker-compose. DNS will still function because it is added directly to nodes' hosts files (ex: /etc/hosts). If you would like to disable DNS propagation entirely, in your docker-compose env for netmaker, set DNS_MODE="off"
 
 .. _NoDocker:
 
 Linux Install without Docker
 =============================
 
-Most systems support Docker, but some do not. In such environments, there are many options for installing Netmaker. Netmaker is available as a binary file, and there is a zip file of the Netmaker UI static HTML on GitHub. Beyond the UI and Server, you may want to optionally install a database (sqlite is embedded, rqlite or postgres are supported) and CoreDNS (also optional). 
+Most systems support Docker, but some do not. In such environments, there are many options for installing Netmaker. Netmaker is available as a binary file, and there is a zip file of the Netmaker UI static HTML on GitHub. Beyond the UI and Server, you may want to optionally install a database (SQLite is embedded, rqlite or postgres are supported) and CoreDNS (also optional). 
 
 Once this is enabled and configured for a domain, you can continue with the below. The recommended server runs Ubuntu 20.04.
 
 Database Setup (optional)
 --------------------------
 
-You can run the netmaker binary standalone and it will run an embedded sqlite server. Data goes in the data/ directory. Optionally, you can run PostgreSQL or rqlite. Instructions for rqlite are below.
+You can run the netmaker binary standalone and it will run an embedded SQLite server. Data goes in the data/ directory. Optionally, you can run PostgreSQL or rqlite. Instructions for rqlite are below.
 
 1. Install rqlite on your server: https://github.com/rqlite/rqlite
 
@@ -254,7 +254,7 @@ Server Setup
 UI Setup
 -----------
 
-The following uses Nginx as an http server. You may alternatively use Apache or any other web server that serves static web files.
+The following uses Nginx as an http server. Alternatively, you may use Apache or any other web server that serves static web files.
 
 1. Download and Unzip UI asset files
 2. Copy Config to Nginx or other reverse proxy
@@ -275,7 +275,7 @@ The following uses Nginx as an http server. You may alternatively use Apache or 
 Proxy / Load Balancer
 ------------------------
 
-You will need to proxy connections to your UI and Server. By default the ports are 8081, 8082. This proxy should handle SSL certificates. We recommend Caddy or Nginx (you can follow the Nginx guide in these docs).
+You will need to proxy connections to your UI and Server. By default, the ports are 8081, 8082. This proxy should handle SSL certificates. We recommend Caddy or Nginx (you can follow the Nginx guide in these docs).
 
 MQ
 ----
@@ -331,7 +331,7 @@ For a more detailed guide on integrating Netmaker with MicroK8s, `check out this
 Nginx Reverse Proxy Setup with https
 ======================================
 
-The `Swag Proxy <https://github.com/linuxserver/docker-swag>`_ makes it easy to generate a valid ssl certificate for the config bellow. Here is the `documentation <https://docs.linuxserver.io/general/swag>`_ for the installation.
+The `Swag Proxy <https://github.com/linuxserver/docker-swag>`_ makes it easy to generate a valid SSL certificate for the config below. Here is the `documentation <https://docs.linuxserver.io/general/swag>`_ for the installation.
 
 The following file configures Netmaker as a subdomain. This config is an adaption from the swag proxy project.
 
@@ -430,7 +430,7 @@ The below command will install netmaker with two server replicas, a coredns serv
     --set dns.clusterIP=10.245.75.75 --set dns.RWX.storageClassName=nfs \
     --set ingress.className=nginx
 
-The below command will install netmaker with three server replicas (the default), **no coredns**, and ingress with routes of api.netmaker.example.com, grpc.netmaker.example.com, and dashboard.netmaker.example.com. There will be one UI replica instead of two, and one database instance instead of two. Traefik will look for a ClusterIssuer named "le-prod-2" to get valid certificates for the ingress. 
+The below command will install netmaker with three server replicas (the default), **no coredns**, and ingress with routes of api.netmaker.example.com, grpc.netmaker.example.com, and dashboard.netmaker.example.com. There will be one UI replica instead of two and one database instance instead of two. Traefik will look for a ClusterIssuer named "le-prod-2" to get valid certificates for the ingress. 
 
 .. code-block::
 
@@ -460,7 +460,7 @@ There are some example ingress objects in the kube/example folder.
 
 Kernel WireGuard
 ------------------
-If you have control of the Kubernetes worker node servers, we recommend **first** installing WireGuard on the hosts, and then installing HA Netmaker in Kernel mode. By default, Netmaker will install with userspace WireGuard (wireguard-go) for maximum compatibility, and to avoid needing permissions at the host level. If you have installed WireGuard on your hosts, you should install Netmaker's helm chart with the following option:
+If you have control of the Kubernetes worker node servers, we recommend **first** installing WireGuard on the hosts, and then installing HA Netmaker in Kernel mode. By default, Netmaker will install with userspace WireGuard (wireguard-go) for maximum compatibility and to avoid needing permissions at the host level. If you have installed WireGuard on your hosts, you should install Netmaker's helm chart with the following option:
 
 - `--set wireguard.kernel=true`
 
@@ -507,12 +507,12 @@ If using PostgreSQL, follow their documentation for `installing in HA mode <http
 
 Your load balancer of choice will send requests to the Netmaker servers. Setup is similar to the various guides we have created for Nginx, Caddy, and Traefik. SSL certificates must also be configured and handled by the LB.
 
-2. RQLite Setup
+2. rqlite Setup
 ------------------
 
-RQLite is the included distributed datastore for an HA Netmaker installation. If you have a different corporate database you wish to integrate, Netmaker is easily extended to other DB's. If this is a requirement, please contact us.
+rqlite is the included distributed datastore for an HA Netmaker installation. If you have a different corporate database you wish to integrate, Netmaker is easily extended to other DB's. If this is a requirement, please contact us.
 
-Assuming you use Rqlite, you must run it on each Netmaker server VM, or alongside that VM as a container. Setup a config.json for database credentials (password supports BCRYPT HASHING) and mount in working directory of rqlite and specify with `-auth config.json` :
+Assuming you use rqlite, you must run it on each Netmaker server VM, or alongside that VM as a container. Setup a config.json for database credentials (password supports BCRYPT HASHING) and mount in working directory of rqlite and specify with `-auth config.json` :
 
 .. code-block::
 
@@ -543,7 +543,7 @@ Once rqlite instances have been configured, the Netmaker servers can be deployed
 3. Netmaker Setup
 ------------------
 
-Netmaker will be started on each node with default settings, except with DATABASE=rqlite (or DATABASE=postgress) and SQL_CONN set appropriately to reach the local rqlite instance. Rqlite will maintain consistency with each Netmaker backend.
+Netmaker will be started on each node with default settings, except with DATABASE=rqlite (or DATABASE=postgress) and SQL_CONN set appropriately to reach the local rqlite instance. rqlite will maintain consistency with each Netmaker backend.
 
 If deploying HA with PostgreSQL, you will connect with the following settings:
 

--- a/support.rst
+++ b/support.rst
@@ -5,12 +5,12 @@ Support
 FAQ
 ======
 
-Is Netmaker a VPN like NordNPN?
+Is Netmaker a VPN like NordVPN?
 --------------------------------
 
 No. Netmaker makes Virtual Networks, which are technically VPNs, but different. It's more like a corporate VPN, or a VPC (if you're familiar with AWS). Netmaker is often compared to OpenVPN, Tailscale, or Nebula.
 
-If you're looking to achieve self-hosted web browsing, with functionality similar to NordVPN, ExpressVPN, Surfshark, Tunnelbear, or Private Internet Access, this is probably not the project for you. Technically, you can accomplish this with Netmaker, but it would be a little like using a all-terrain vehicle for stock car racing.
+If you're looking to achieve self-hosted web browsing, with functionality similar to NordVPN, ExpressVPN, Surfshark, Tunnelbear, or Private Internet Access, this is probably not the project for you. Technically, you can accomplish this with Netmaker, but it would be a little like using an all-terrain vehicle for stock car racing.
 
 There are many good projects out there that support general internet privacy using WireGuard. Here are just a few of them:
 
@@ -35,7 +35,7 @@ Why the SSPL License?
 
 As of now, we think the SSPL is the best way to ensure the long-term viability of the project, but we are regularly evaluating this to see if an OSI-approved license makes more sense.
 
-We believe the SSPL lets most people run the project the way they want, for both for private use and business use, while giving us a path to maintain viability. We are working to make sure the guidelines clear, and do not want the license to impact the community's ability to use and modify the project.
+We believe the SSPL lets most people run the project the way they want, for both private use and business use, while giving us a path to maintain viability. We are working to make sure the guidelines clear, and do not want the license to impact the community's ability to use and modify the project.
 
 If you believe the SSPL will negatively impact your ability to use the project, please do not hesitate to reach out.
 
@@ -44,7 +44,7 @@ Telemetry
 
 As of v0.10.0, Netmaker collects "opt-out" telemetry data. To opt out, simply set "TELEMETRY=off" in your docker-compose file.
 
-Please consider participating in telemetry, as it helps us focus on the features and bug fixes which are most useful to users. Netmaker is a broad platform, and without this data, it is difficult to know where the team should spend its limited resources.
+Please consider participating in telemetry, as it helps us focus on the features and bug fixes that are most useful to users. Netmaker is a broad platform, and without this data, it is difficult to know where the team should spend its limited resources.
 
 The following is the full list of telemetry data we collect. Besides "Server Version" all data is simply an integer count:
 
@@ -68,7 +68,7 @@ To look at exactly we collect telemetry, you can view the source code under serv
 
 Contact
 ===========
-If you need help, try the discord or open a GitHub ticket.
+If you need help, try the Discord or open a GitHub ticket.
 
 Email: info@gravitl.com
 

--- a/troubleshoot.rst
+++ b/troubleshoot.rst
@@ -5,21 +5,21 @@ Troubleshooting
 Common Issues
 --------------
 **How can I connect my Android or IOS device to my Netmaker VPN?**
-  Currently meshing one of these devices is not supported, however it will be soon. 
-  For now you can connect to your VPN by making one of the nodes an Ingress Gateway, then 
+  Currently meshing one of these devices is not supported, however, it will be soon. 
+  For now, you can connect to your VPN by making one of the nodes an Ingress Gateway, then 
   create an Ext Client for each device. Finally, use the official WG app or another 
-  WG configuration app to connect via QR or downloading the device's WireGuard configuration. 
+  WG configuration app to connect via QR or download the device's WireGuard configuration. 
 
 **I've made changes to my nodes but the nodes themselves haven't updated yet, why?**
-  Please allow your nodes to complete a check in or two, in order to reconfigure themselves.
+  Please allow your nodes to complete a check-in or two, in order to reconfigure themselves.
   In some cases, it could take up to a minute or so.
 
 **Do I have to use access keys to join a network?**
   Although keys are the preferred way to join a network, Netmaker does allow for manual node sign-ups.
-  Simply turn on "allow manual signups" on your network and nodes will not connect until you manually aprove each one.
+  Simply turn on "allow manual signups" on your network and nodes will not connect until you manually approve each one.
 
 **Is there a community or forum to ask questions about Netmaker?**
-  Yes, we have an active `discord <https://discord.gg/Pt4T9y9XK8>`_ community and issues on our `github <https://github.com/gravitl/netmaker/issues>`_ are answered frequently!
+  Yes, we have an active `Discord <https://discord.gg/Pt4T9y9XK8>`_ community and issues on our `GitHub <https://github.com/gravitl/netmaker/issues>`_ are answered frequently!
   You can also sign-up for updates at our `gravitl site <https://gravitl.com/>`_!
 
 **How can I get additional support for my business?**
@@ -36,16 +36,16 @@ Server
 
   One a netclient is deployed to the underlying server/VM, you will be able to use the private address to reach other nodes from the host, or to reach the server over the private network.
 
-**I upgraded from 0.7 to 0.8 and now I dont have any data in my server!**
-  In 0.8, sqlite becomes the default database. If you were running with rqlite, you must set the DATABASE environment variable to rqlite in order to continue using rqlite.
+**I upgraded from 0.7 to 0.8 and now I don't have any data in my server!**
+  In 0.8, SQLite becomes the default database. If you were running with rqlite, you must set the DATABASE environment variable to rqlite in order to continue using rqlite.
 
 **Can I secure/encrypt all the traffic to my server and UI?**
-  This can fairly simple to achieve assuming you have access to a domain and are familiar with Nginx.
+  This can be fairly simple to achieve assuming you have access to a domain and are familiar with Nginx.
   Please refer to the quick-start guide to see!
 
 **Can I connect multiple nodes (mesh clients) behind a single firewall/router?**
-  Yes! As of version 0.7 Netmaker supports UDP Hole Punching to allow this, without the use of a third party STUN server!
-  Is UDP hole punching a risk for you? Well you can turn it off and make static nodes/ports for the server to refer to as well.
+  Yes! As of version 0.7 Netmaker supports UDP Hole Punching to allow this, without the use of a third-party STUN server!
+  Is UDP hole punching a risk for you? Well, you can turn it off and make static nodes/ports for the server to refer to as well.
 
 **What are the minimum specs to run the server?**
   We recommend at least 1 CPU and 2 GB Memory.
@@ -72,19 +72,19 @@ Please follow this Gist if you are encountering issues with 0.13+: https://gist.
 
 UI
 ----
-**I want to make a seperate network and give my friend access to only that network.**
-  Simply navigate to the UI (as an admin account). Select users in the top left and create them an account.
+**I want to make a separate network and give my friend access to only that network.**
+  Simply navigate to the UI (as an admin account). Select users in the top left and create an account for them.
   Select the network(s) to give them and they should be good to go! They are an admin of that network(s) only now.
 
 **I'm done with an access key, can I delete it?**
-  Simply navigate to the UI (as an admin account). Select your network of interest, then the select the ``Access Keys`` tab.
+  Simply navigate to the UI (as an admin account). Select your network of interest, then select the ``Access Keys`` tab.
   Then delete the rogue access key.
 
 **I can't delete my network, why?**
   You **MUST** remove all nodes in a network before you can delete it.
 
 **Can I have multiple nodes with the same name?**
-  Yes, nodes can share names without issue. It may just be harder on you to know which is which.
+  Yes, nodes can share names without issue. It may just be harder for you to know which is which.
 
 Netclient
 -----------
@@ -119,7 +119,7 @@ Netclient
   This is commonly due to incorrect MTU settings. Typically, it will be because MTU is too high. Try setting MTU lower on the node. This can be done via netconfig, or by editing the node in the UI. 
 
 **I have a hard to reach machine behind a firewall or a corporate NAT, what can I do?**
-  In this situation you can use the Relay Server functionality introduced in Netmaker v0.8 to designate a node as a relay to your "stuck" machine. Simply click the button to make a node into a relay and tell it to relay traffic to this hard-to-reach peer. 
+  In this situation, you can use the Relay Server functionality introduced in Netmaker v0.8 to designate a node as a relay to your "stuck" machine. Simply click the button to make a node into a relay and tell it to relay traffic to this hard-to-reach peer. 
 
 **I am unable to run the netclient on my OpenWRT machine, what's wrong?**
   Deploying on OpenWRT depends a lot on the version of OpenWRT and the hardware being used. If the primary installer does not work, there are two things you can try:

--- a/upgrades.rst
+++ b/upgrades.rst
@@ -5,7 +5,7 @@ Upgrades
 Introduction
 ===============
 
-As of 0.13.0, upgrading Netmaker is a manual process. This is expected to be automated in the future, but for now is still a relatively straightforward process. 
+As of 0.13.0, upgrading Netmaker is a manual process. This is expected to be automated in the future, but for now, is still a relatively straightforward process. 
 
 Critical Notes for 0.13.X
 ================================
@@ -36,7 +36,7 @@ Upgrade the Clients (prior to 0.10.0)
 
 To upgrade the client, you must get the new client binary and place it in /etc/netclient. Depending on the new vs. old version, there may be minor incompatibilities (discussed below).
 
-1. Vists https://github.com/gravitl/netmaker/releases/
+1. Visit https://github.com/gravitl/netmaker/releases/
 2. Find the appropriate binary for your machine.
 3. Download. E.x.: `wget https://github.com/gravitl/netmaker/releases/download/vX.X.X/netclient-myversion`
 4. Rename binary to `netclient` and move to folder. E.x.: `mv netclient-myversion /etc/netclient/netclient`


### PR DESCRIPTION
spelling/typos
commas: remove extraneous, add missing
start making capitalization consistent
remove extra spaces