### PR TITLE
Hotfix 0.17.1 remove orphaned code from docs

### DIFF
--- a/examplecode/dev.yaml
+++ b/examplecode/dev.yaml
@@ -6,7 +6,6 @@ server:
   masterkey: "" # defaults to 'secretkey' or MASTER_KEY (if set)
   allowedorigin: "" # defaults to '*' or CORS_ALLOWED_ORIGIN (if set)
   restbackend: "" # defaults to "on" or REST_BACKEND (if set)
-  agentbackend: "" # defaults to "on" or AGENT_BACKEND (if set)
   clientmode: "" # defaults to "on" or CLIENT_MODE (if set)
   dnsmode: "" # defaults to "on" or DNS_MODE (if set)
   sqlconn: "" # defaults to "http://" or SQL_CONN (if set)

--- a/examplecode/dev.yaml
+++ b/examplecode/dev.yaml
@@ -1,8 +1,6 @@
 server:
   apihost: "" # defaults to 127.0.0.1 or remote ip (SERVER_HOST) if DisableRemoteIPCheck is not set to true. SERVER_API_HOST if set
   apiport: "" # defaults to 8081 or HTTP_PORT (if set)
-  grpchost: "" # defaults to 127.0.0.1 or remote ip (SERVER_HOST) if DisableRemoteIPCheck is not set to true. SERVER_GRPC_HOST if set.
-  grpcport: "" # defaults to 50051 or GRPC_PORT (if set)
   masterkey: "" # defaults to 'secretkey' or MASTER_KEY (if set)
   allowedorigin: "" # defaults to '*' or CORS_ALLOWED_ORIGIN (if set)
   restbackend: "" # defaults to "on" or REST_BACKEND (if set)

--- a/server-installation.rst
+++ b/server-installation.rst
@@ -169,12 +169,6 @@ PORT_FORWARD_SERVICES:
 
     **Description:** Comma-separated list of services for which to configure port forwarding on the machine. Options include "mq,dns,ssh". MQ IS DEPRECIATED, DO NOT SET THIS.'ssh' forwards port 22 over WireGuard, enabling ssh to server over WireGuard. However, if you set the Netmaker server as an ingress gateway, this will break SSH on external clients, so be careful. DNS enables private DNS over WireGuard. If you would like to use private DNS with ext clients, turn this on.
 
-POD_IP: 
-    **Default:** "127.0.0.1"
-
-    **Description:** Specific to a Kubernetes installation. Gets the container IP address of the pod where Netmaker is running.
-
-
 VERBOSITY:
     **Default:** 0
 

--- a/server-installation.rst
+++ b/server-installation.rst
@@ -124,11 +124,6 @@ RCE:
 
     **Description:** The server enables you to set PostUp and PostDown commands for nodes, which is standard for WireGuard with wg-quick, but is also **Remote Code Execution**, which is a critical vulnerability if the server is exploited. Because of this, it's turned off by default, but if turned on, PostUp and PostDown become editable.
 
-DEFAULT_NODE_LIMIT
-    **Default:** "999999999"
-
-    **Description:** Limits the number of nodes allowed on the server (total).
-
 DISPLAY_KEYS
     **Default:** "on"
 

--- a/server-installation.rst
+++ b/server-installation.rst
@@ -79,11 +79,6 @@ REST_BACKEND:
 
     **Description:** Enables the REST backend (API running on API_PORT at SERVER_HTTP_HOST). Change to "off" to turn off.
 
-AGENT_BACKEND:  
-    **Default:** "on" 
-
-    **Description:** Enables the AGENT backend (GRPC running on GRPC_PORT at SERVER_GRPC_HOST). Change to "off" to turn off.
-
 DNS_MODE:  
     **Default:** "off"
 


### PR DESCRIPTION
Remove documentation related to orphaned code. Corresponding netmaker PR: https://github.com/gravitl/netmaker/pull/2053