### PR TITLE
use netclient binary for windows/mac

### DIFF
--- a/upgrades.rst
+++ b/upgrades.rst
@@ -62,8 +62,7 @@ Steps
 3. After the upgrade, you should see only one host in the Netmaker UI. It will have the same name as the hostname of your server, rather than netmaker-1.
 4. Upgrade your netclients 
 
-  a. Linux/Freebsd: On each client download `the latest version <https://fileserver.netmaker.io/releases/download>`_ of netclient and run the `netclient install` command 
-  b. Windows/MacOS: On each client download the `the latest installer package <https://fileserver.netmaker.io/releases/download>`_ (.MSI or .PKG) for netclient and run the installer
+  a. On each client download `the latest version <https://fileserver.netmaker.io/releases/download>`_ of netclient and run the `netclient install` command 
 
 5. As each netclient is updated, check that a new host, nodes, and gateways (if applicable) are visible in the Netmaker UI.
 6. If upgrading to EE, recreate any relay gateways


### PR DESCRIPTION
v0.17.1 does not have gui so the upgrade process for all OS's should just download the netclient binary and run
`./netclient install`